### PR TITLE
Adding options to command line execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,56 @@
 # ecs-task-run
 
-**Install**
+## Install
 
 ```bash
 $ pip install ecs-task-run
 ```
 
-**Using**
+## Using
 
+### Running tasks:
 ```bash
-$ ecs-task-run --cluster YOUR_CLUSTER_NAME --task YOUR_TASK_DEFINITION --image YOUR_IMAGE
+$ ecs-task-run task --cluster YOUR_CLUSTER_NAME --task YOUR_TASK_DEFINITION --image YOUR_IMAGE
 ```
+or:
+```bash
+$ ecs-task-run task -c YOUR_CLUSTER_NAME -t YOUR_TASK_DEFINITION -i YOUR_IMAGE
+```
+
+### Updating Services:
+```bash
+$ ecs-task-run update-service --cluster YOUR_CLUSTER_NAME --task YOUR_TASK_DEFINITION --image YOUR_IMAGE --service YOUR_SERVICE_NAME
+```
+or:
+```bash
+$ ecs-task-run update-service -c YOUR_CLUSTER_NAME -t YOUR_TASK_DEFINITION -i YOUR_IMAGE -s YOUR_SERVICE_NAME
+```
+
+### Running a deploy config
+To run a list of jobs from a file.
+```bash
+ecs-task-run run-config --path LOCAL_PATH_TO_CONFIG
+```
+or
+```bash
+ecs-task-run run-config -p LOCAL_PATH_TO_CONFIG
+```
+
+Example config:
+```json
+[{
+"task_option":"task",
+"task":"YOUR_TASK_DEFINITION",
+"image":"YOUR_IMAGE",
+"cluster":"YOUR_CLUSTER_NAME"
+},
+{
+"task_option":"update-service",
+"task":"YOUR_TASK_DEFINITION",
+"service":"YOUR_SERVICE_NAME",
+"image":"YOUR_IMAGE",
+"cluster":"YOUR_CLUSTER_NAME"
+}]
+```
+
+

--- a/README.md
+++ b/README.md
@@ -10,30 +10,34 @@ $ pip install ecs-task-run
 
 ### Running tasks:
 ```bash
-$ ecs-task-run task --cluster YOUR_CLUSTER_NAME --task YOUR_TASK_DEFINITION --image YOUR_IMAGE
+$ ecs-task-run --cluster YOUR_CLUSTER_NAME --task YOUR_TASK_DEFINITION --image YOUR_IMAGE
 ```
 or:
 ```bash
-$ ecs-task-run task -c YOUR_CLUSTER_NAME -t YOUR_TASK_DEFINITION -i YOUR_IMAGE
+$ ecs-run task --cluster YOUR_CLUSTER_NAME --task YOUR_TASK_DEFINITION --image YOUR_IMAGE
+```
+or:
+```bash
+$ ecs-run task -c YOUR_CLUSTER_NAME -t YOUR_TASK_DEFINITION -i YOUR_IMAGE
 ```
 
 ### Updating Services:
 ```bash
-$ ecs-task-run update-service --cluster YOUR_CLUSTER_NAME --task YOUR_TASK_DEFINITION --image YOUR_IMAGE --service YOUR_SERVICE_NAME
+$ ecs-run update-service --cluster YOUR_CLUSTER_NAME --task YOUR_TASK_DEFINITION --image YOUR_IMAGE --service YOUR_SERVICE_NAME
 ```
 or:
 ```bash
-$ ecs-task-run update-service -c YOUR_CLUSTER_NAME -t YOUR_TASK_DEFINITION -i YOUR_IMAGE -s YOUR_SERVICE_NAME
+$ ecs-run update-service -c YOUR_CLUSTER_NAME -t YOUR_TASK_DEFINITION -i YOUR_IMAGE -s YOUR_SERVICE_NAME
 ```
 
 ### Running a deploy config
 To run a list of jobs from a file.
 ```bash
-ecs-task-run run-config --path LOCAL_PATH_TO_CONFIG
+ecs-run run-config --path LOCAL_PATH_TO_CONFIG
 ```
 or
 ```bash
-ecs-task-run run-config -p LOCAL_PATH_TO_CONFIG
+ecs-run run-config -p LOCAL_PATH_TO_CONFIG
 ```
 
 Example config:

--- a/README.md
+++ b/README.md
@@ -33,23 +33,23 @@ $ ecs-run update-service -c YOUR_CLUSTER_NAME -t YOUR_TASK_DEFINITION -i YOUR_IM
 ### Running a deploy config
 To run a list of jobs from a file.
 ```bash
-ecs-run run-config --path LOCAL_PATH_TO_CONFIG
+ecs-run run-jobs --path LOCAL_PATH_TO_CONFIG
 ```
 or
 ```bash
-ecs-run run-config -p LOCAL_PATH_TO_CONFIG
+ecs-run run-jobs -p LOCAL_PATH_TO_CONFIG
 ```
 
 Example config:
 ```json
 [{
-"task_option":"task",
+"job_option":"task",
 "task":"YOUR_TASK_DEFINITION",
 "image":"YOUR_IMAGE",
 "cluster":"YOUR_CLUSTER_NAME"
 },
 {
-"task_option":"update-service",
+"job_option":"update-service",
 "task":"YOUR_TASK_DEFINITION",
 "service":"YOUR_SERVICE_NAME",
 "image":"YOUR_IMAGE",

--- a/ecs_task_run/__init__.py
+++ b/ecs_task_run/__init__.py
@@ -1,25 +1,85 @@
 import argparse
+import json
+import os
+
 from .client import Client
 
 
-def main():
-
-    parser = argparse.ArgumentParser(description='ECS Task Run')
-    parser.add_argument('--cluster')
-    parser.add_argument('--task')
-    parser.add_argument('--image')
-    args = parser.parse_args()
-    cluster_name = args.cluster
-    task_family = args.task
-    image_name = args.image
-
+def run_task(cluster_name, image_name, task_family):
+    if cluster_name is None:
+        raise Exception('argument --cluster should not be none')
+    if task_family is None:
+        raise Exception('argument --task should not be none')
+    if image_name is None:
+        raise Exception('argument --image should not be none')
     client = Client(cluster_name, image_name)
     updated_container = client.update_container(task_family)
     task_id = client.run_task(updated_container, task_family=task_family)
-
+    print('Started task {0}'.format(task_id))
     client.wait_for_task(task_id)
     print('Task {0} finished'.format(task_id))
     print('Task output:')
 
     for log_message in client.get_logs_for_task(updated_container, task_id):
         print('  > {0}'.format(log_message))
+
+
+def run_update_service(cluster_name, image_name, service_name, task_family):
+    if cluster_name is None:
+        raise Exception('argument --cluster should not be none')
+    if task_family is None:
+        raise Exception('argument --task should not be none')
+    if image_name is None:
+        raise Exception('argument --image should not be none')
+    if service_name is None:
+        raise Exception('argument --service should not be none')
+    client = Client(cluster_name, image_name)
+    updated_container = client.update_container(task_family)
+    client.update_service(
+            container_definition=updated_container,
+            service=service_name,
+            task_family=task_family,
+            )
+    print('Triggered service:{} updated'.format(service_name))
+
+def main():
+    parser = argparse.ArgumentParser(description='ECS Run')
+    parser.add_argument('task_option', help='options:update-service, task, run-config')
+    parser.add_argument('--cluster', '-c')
+    parser.add_argument('--task', '-t')
+    parser.add_argument('--image', '-i')
+    parser.add_argument('--service', '-s')
+    parser.add_argument('--path', '-p')
+    args = parser.parse_args()
+
+    if args.task_option == 'run-config':
+        current_full_path = os.path.abspath(os.path.curdir)
+        with open(os.path.join(current_full_path, args.path), 'r') as file:
+            run_file_list = json.load(file)
+        for item_to_run in run_file_list:
+            task_option = item_to_run['task_option']
+            cluster = item_to_run.get('cluster', None)
+            task = item_to_run.get('task', None)
+            image = item_to_run.get('image', None)
+            service = item_to_run.get('service', None)
+            print('Stating to run:{} updated'.format(task_option))
+            if task_option == 'task':
+                run_task(cluster_name=cluster,
+                         task_family=task,
+                         image_name=image)
+            elif task_option == 'update-service':
+                run_update_service(cluster_name=cluster,
+                                   task_family=task,
+                                   image_name=image,
+                                   service_name=service)
+
+    if args.task_option == 'task':
+        run_task(cluster_name=args.cluster,
+                 image_name=args.image,
+                 task_family=args.task)
+
+    if args.task_option == 'update-service':
+        run_update_service(cluster_name=args.cluster,
+                           image_name=args.image,
+                           task_family=args.task,
+                           service_name=args.service)

--- a/ecs_task_run/__init__.py
+++ b/ecs_task_run/__init__.py
@@ -53,6 +53,18 @@ def run_update_service(cluster_name, image_name, service_name, task_family):
         sys.exit(1)
 
 def main():
+    parser = argparse.ArgumentParser(description='ECS Task Run')
+    parser.add_argument('--cluster')
+    parser.add_argument('--task')
+    parser.add_argument('--image')
+    args = parser.parse_args()
+
+    run_task(cluster_name=args.cluster,
+             image_name=args.image,
+             task_family=args.task)
+    sys.exit(0)
+
+def ecs_run():
     parser = argparse.ArgumentParser(description='ECS Run')
     parser.add_argument('task_option', help='options:update-service, task, run-config')
     parser.add_argument('--cluster', '-c')

--- a/ecs_task_run/client.py
+++ b/ecs_task_run/client.py
@@ -72,3 +72,10 @@ class Client(object):
         )
 
         return registered['taskDefinition']['taskDefinitionArn']
+
+    def get_exit_status_for_task(self, task_id):
+        task_info = self.ecs_client.describe_tasks(
+            cluster=self.cluster_name,
+            tasks=[task_id]
+        )['tasks'][0]
+        return task_info['containers'][0]['exitCode']

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/creditas/ecs-task-run",
     packages=setuptools.find_packages(),
-    entry_points={"console_scripts": ["ecs-task-run=ecs_task_run:main"]},
+    entry_points={"console_scripts": ["ecs-task-run=ecs_task_run:main",
+                                      "ecs-run=ecs_task_run:ecs_run"]},
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Adicionei um novo alias `ecs-run` com os seguintes possiveis comandos:
 - `task` para rodar uma task no ECS.
 - `update-service` para atualizar um serviço no ECS.
 - `run-jobs` para rodar uma lista de jobs em um arquivo JSON conforme o README.

Adicionei uma validação básica para garantir que todos os argumentos necessários foram passados pelo usuário.

Inclui as alterações sugeridas pelo @dkotvan para garantir que o programa levante um exit_code apropriado dada a execução de qualquer função.