### PR TITLE
Adicionando tratamento de erro na run-task

### DIFF
--- a/ecs_task_run/__init__.py
+++ b/ecs_task_run/__init__.py
@@ -13,20 +13,26 @@ def run_task(cluster_name, image_name, task_family):
         raise Exception('argument --task should not be none')
     if image_name is None:
         raise Exception('argument --image should not be none')
-    client_instance = Client(cluster_name, image_name)
-    updated_container = client_instance.update_container(task_family)
-    task_id = client_instance.run_task(updated_container, task_family=task_family)
-    print('Started task {0}'.format(task_id))
-    client_instance.wait_for_task(task_id)
-    print('Task output:')
 
-    for log_message in client_instance.get_logs_for_task(updated_container, task_id):
-        print('  > {0}'.format(log_message))
+    try:
+        client_instance = Client(cluster_name, image_name)
+        updated_container = client_instance.update_container(task_family)
+        task_id = client_instance.run_task(updated_container, task_family=task_family)
+        print('Started task {0}'.format(task_id))
+        client_instance.wait_for_task(task_id)
+        print('Task output:')
 
-    exit_status = client_instance.get_exit_status_for_task(task_id)
-    print('Task {0} finished with status code:{1}'.format(task_id, exit_status))
-    if exit_status != 0:
-        sys.exit(exit_status)
+        for log_message in client_instance.get_logs_for_task(updated_container, task_id):
+            print('  > {0}'.format(log_message))
+
+        exit_status = client_instance.get_exit_status_for_task(task_id)
+        print('Task {0} finished with status code:{1}'.format(task_id, exit_status))
+        if exit_status != 0:
+            sys.exit(exit_status)
+    except Exception as error:
+        print('Run Task Failed:{}'.format(image_name))
+        print(error)
+        sys.exit(1)
 
 def run_update_service(cluster_name, image_name, service_name, task_family):
     if cluster_name is None:

--- a/ecs_task_run/client.py
+++ b/ecs_task_run/client.py
@@ -44,7 +44,7 @@ class Client(object):
             taskDefinition=new_definition_arn
         )
 
-        if len(task['failures']) > 0:
+        if len(task.get('failures')) > 0:
             raise Exception('Run Task Failed - {}'.format(task['failures']))
 
         return task['tasks'][0]['taskArn'].split('/')[1]

--- a/ecs_task_run/client.py
+++ b/ecs_task_run/client.py
@@ -44,7 +44,7 @@ class Client(object):
             taskDefinition=new_definition_arn
         )
 
-        if len(task.get('failures')) > 0:
+        if len(task.get('failures', [])) > 0:
             raise Exception('Run Task Failed - {}'.format(task['failures']))
 
         return task['tasks'][0]['taskArn'].split('/')[1]

--- a/ecs_task_run/client.py
+++ b/ecs_task_run/client.py
@@ -43,6 +43,10 @@ class Client(object):
             cluster=self.cluster_name,
             taskDefinition=new_definition_arn
         )
+
+        if len(task['failures']) > 0:
+            raise Exception('Run Task Failed - {}'.format(task['failures']))
+
         return task['tasks'][0]['taskArn'].split('/')[1]
 
     def wait_for_task(self, task_id):


### PR DESCRIPTION
## Por Que?
Ao criar uma nova aplicação de leitura de cnab de servicing. Me deparei que precisava utilizar esta aplicação para rodar task de forma individualizada para migrations da aplicação em um cluster `ECS`.
Porém, nas minhas primeiras tentativas está recebendo erro do `run-task` sem nenhum  feedback.

## O Que foi Feito
- Realizado um tratamento de exceção para o método de run-task
- Verificando se o retorno do `run-task` contêm `failures` para parar a execeção e lançar um erro