### PR TITLE
Adding execution_role_arn argument to update-service

### DIFF
--- a/ecs_task_run/__init__.py
+++ b/ecs_task_run/__init__.py
@@ -34,6 +34,7 @@ def run_task(cluster_name, image_name, task_family):
         print(error)
         sys.exit(1)
 
+
 def run_update_service(cluster_name, image_name, service_name, task_family):
     if cluster_name is None:
         raise Exception('argument --cluster should not be none')
@@ -58,6 +59,7 @@ def run_update_service(cluster_name, image_name, service_name, task_family):
         print(error)
         sys.exit(1)
 
+
 def process_job_item(job_item):
     job_option = job_item.get('job_option', None)
     cluster = job_item.get('cluster', None)
@@ -76,6 +78,7 @@ def process_job_item(job_item):
                            service_name=service)
     else:
         raise Exception("Invalid job_option")
+
 
 def main():
     parser = argparse.ArgumentParser(description='ECS Task Run')

--- a/ecs_task_run/__init__.py
+++ b/ecs_task_run/__init__.py
@@ -89,6 +89,7 @@ def main():
              task_family=args.task)
     sys.exit(0)
 
+
 def ecs_run():
     parser = argparse.ArgumentParser(description='ECS Run')
     parser.add_argument('job_option', help='options:update-service, task, run-jobs')
@@ -97,6 +98,7 @@ def ecs_run():
     parser.add_argument('--image', '-i')
     parser.add_argument('--service', '-s')
     parser.add_argument('--path', '-p')
+    parser.add_argument('--executionrole', '-ex')
     args = parser.parse_args()
 
     if args.job_option == 'run-jobs':
@@ -117,7 +119,8 @@ def ecs_run():
         run_update_service(cluster_name=args.cluster,
                            image_name=args.image,
                            task_family=args.task,
-                           service_name=args.service)
+                           service_name=args.service,
+                           execution_role_arn=args.executionrolearn)
         sys.exit(0)
     else:
         raise Exception('Invalid job_option, should be: task, update-service, run-jobs')

--- a/ecs_task_run/__init__.py
+++ b/ecs_task_run/__init__.py
@@ -101,7 +101,7 @@ def ecs_run():
     parser.add_argument('--image', '-i')
     parser.add_argument('--service', '-s')
     parser.add_argument('--path', '-p')
-    parser.add_argument('--executionrole', '-ex')
+    parser.add_argument('--executionrolearn', '-ex')
     args = parser.parse_args()
 
     if args.job_option == 'run-jobs':

--- a/ecs_task_run/client.py
+++ b/ecs_task_run/client.py
@@ -69,10 +69,12 @@ class Client(object):
 
         return [e['message'] for e in events['events']]
 
-    def _update_task_definition(self, container_definition, task_family):
+    def _update_task_definition(self, container_definition, task_family,
+                                execution_role_arn=None):
         registered = self.ecs_client.register_task_definition(
             family=task_family,
-            containerDefinitions=[container_definition]
+            containerDefinitions=[container_definition],
+            executionRoleArn=execution_role_arn
         )
 
         return registered['taskDefinition']['taskDefinitionArn']


### PR DESCRIPTION
## Contexto/O que?
Eu tenho um build de serviço que está falhando no CI com a seguinte mensagem de erro:
`An error occurred (ClientException) when calling the RegisterTaskDefinition operation: When you are specifying container secrets, you must also specify a value for 'executionRoleArn'.`

## O que foi feito?
Adicionado execution_role_arn no comando/função update-service

