### PR TITLE
Utilizando execution role arn existente da task

### DIFF
--- a/ecs_task_run/client.py
+++ b/ecs_task_run/client.py
@@ -69,10 +69,20 @@ class Client(object):
 
         return [e['message'] for e in events['events']]
 
+    def _get_execution_role_arn(self, task_family):
+        task_definition = self.ecs_client.describe_task_definition(
+            taskDefinition=task_family
+        )
+
+        return task_definition['taskDefinition']['executionRoleArn']
+
     def _update_task_definition(self, container_definition, task_family):
+        execution_role_arn = self.get_execution_role_arn(task_family)
+
         registered = self.ecs_client.register_task_definition(
             family=task_family,
-            containerDefinitions=[container_definition]
+            containerDefinitions=[container_definition],
+            executionRoleArn=execution_role_arn
         )
 
         return registered['taskDefinition']['taskDefinitionArn']


### PR DESCRIPTION
# O que?

Por algum motivo especial, o command line da AWS ignora o `executionRoleArn` da task e exige que você sempre o passe. Essa PR busca o role existente da task e repassa para o client da AWS.

Se a task não tiver `executionRoleArn`, será passado `null` e o efeito será o mesmo