### PR TITLE
[BUG] A execução de Task falha quando o executionRoleArn não é definido

### DIFF
--- a/ecs_task_run/client.py
+++ b/ecs_task_run/client.py
@@ -73,8 +73,9 @@ class Client(object):
         task_definition = self.ecs_client.describe_task_definition(
             taskDefinition=task_family
         )
-
-        return task_definition['taskDefinition']['executionRoleArn']
+        if 'executionRoleArn' in task_definition['taskDefinition']:
+            return task_definition['taskDefinition']['executionRoleArn']
+        return
 
     def _update_task_definition(self, container_definition, task_family):
         execution_role_arn = self._get_execution_role_arn(task_family)

--- a/ecs_task_run/client.py
+++ b/ecs_task_run/client.py
@@ -75,7 +75,7 @@ class Client(object):
         )
         if 'executionRoleArn' in task_definition['taskDefinition']:
             return task_definition['taskDefinition']['executionRoleArn']
-        return
+        return ''
 
     def _update_task_definition(self, container_definition, task_family):
         execution_role_arn = self._get_execution_role_arn(task_family)


### PR DESCRIPTION
Em alguns casos a Task foi criada/roda sem um executionRoleArn, e o processo falha para esses casos.